### PR TITLE
Allow superuser to login when password expired. Update warning message.

### DIFF
--- a/password_expire/middleware.py
+++ b/password_expire/middleware.py
@@ -21,6 +21,8 @@ class PasswordExpireMiddleware:
                 time_to_expire_string = checker.get_expire_time()
                 if time_to_expire_string:
                     msg = f'Please change your password. It expires in {time_to_expire_string}.'
+                    if checker.is_expired():
+                        msg = 'Please change your password. It has expired.'
                     self.add_warning(request, msg)
 
         response = self.get_response(request)

--- a/password_expire/signals.py
+++ b/password_expire/signals.py
@@ -58,9 +58,9 @@ def change_password_handler(sender, instance, **kwargs):
 
 
 def login_handler(sender, request, user, **kwargs):
-    # Prevents login if password expired
+    # Prevents login if password expired unless superuser
     checker = PasswordChecker(request.user)
-    if checker.is_expired():
+    if checker.is_expired() and not request.user.is_superuser:
         if hasattr(settings, 'PASSWORD_EXPIRE_CONTACT'):
             contact = settings.PASSWORD_EXPIRE_CONTACT
         else:


### PR DESCRIPTION
The superuser should be able to login.

`humanize` converts a negative timedelta (i.e. password has expired) into "a day", so the warning messages says "Please change your password. It has expires in a day." Change it to "Please change your password. It has expired."